### PR TITLE
pick: avoid pattern matching in do context

### DIFF
--- a/easytest.cabal
+++ b/easytest.cabal
@@ -86,7 +86,7 @@ library
     async                     >= 2.1      && <= 2.3,
     base                      >= 4.5      && <= 5,
     mtl                       >= 2.0.1    && < 2.3,
-    containers                >= 0.4.0    && < 0.6,
+    containers                >= 0.4.0    && < 0.7,
     stm                       >= 2.4      && < 3,
     random                    >= 1.1      && < 2,
     text                      >= 1.2      && < 1.3,

--- a/src/EasyTest/Generators.hs
+++ b/src/EasyTest/Generators.hs
@@ -29,6 +29,7 @@ import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Reader
 import Data.Map (Map)
+import Data.Maybe ( fromJust )
 import Data.Word
 import System.Random (Random)
 import qualified Data.Map as Map
@@ -107,8 +108,8 @@ word8' = random'
 pick :: [a] -> Test a
 pick as = let n = length as; ind = picker n as in do
   i <- int' 0 (n - 1)
-  Just a <- pure (ind i)
-  pure a
+  a <- pure (ind i)
+  pure (fromJust a)             -- TODO: fromJust is not a total function
 
 picker :: Int -> [a] -> (Int -> Maybe a)
 picker _ [] = const Nothing


### PR DESCRIPTION
'Test' is not an instance for MonadFail, so the compiler refuses the pattern
match since it doesn't know how to report an error. We use 'fromJust' for the
moment, which reports it via 'error'.

This change fixes the build with ghc-8.6.x.